### PR TITLE
S3_connection_fix　items_controller params_fix

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -57,7 +57,7 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:name, :introduction, :price,  :condition_id, :postage_burden_id, :prefecture_code, 
     :category_id, :postage_days_id, :seller_id, 
-    item_images_attributes: [:image, :_destroy, :id]).merge(buyer_id: 1)
+    item_images_attributes: [:image, :_destroy, :id]).merge( seller_id: 1)
   end
 
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,7 +10,7 @@ class Item < ApplicationRecord
   belongs_to_active_hash :postage_burden
   belongs_to_active_hash :postage_days
   belongs_to :seller, class_name: "User"
-  belongs_to :buyer, class_name: "User"
+  belongs_to :buyer, class_name: "User", optional: true
 
   validates :item_images, presence: true
   validates :name, presence: true

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -74,8 +74,6 @@
           販売利益
           .right_bar_2
             %p
-        .product_form__purchase{hidden: ""}
-          = form.number_field :seller_id, value: User.find_by(id: 1).id
       .form_section.register_btns
         = form.submit "出品する",class:"exhibition-btn"
       .attentions

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,15 +3,18 @@ require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
-  config.storage = :fog
-  config.fog_provider = 'fog/aws'
-  config.fog_credentials = {
-    provider: 'AWS',
-    aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
-    aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
-    region: 'ap-northeast-1'
-  }
-
-  config.fog_directory  = 'fleamarket80'
-  config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/fleamarket80'
+  if Rails.env.production?
+    config.storage = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+      region: 'ap-northeast-1'
+    }
+    config.fog_directory  = 'fleamarket80'
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/fleamarket80'
+  else
+    config.storage = :file
+  end
 end


### PR DESCRIPTION
##What
S3の記述修正。itemsコントローラーのparamsの値修正。
##Why
画像データの取得先をローカルとS3に分ける為。
商品出品時にbuyer._idなどはnullにしておくべきだったので、修正した為。