### PR TITLE
商品詳細ページの発送元地域の修正

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -76,7 +76,7 @@
           %tr.one
             %th 発送元の地域
             %td 
-              仮）北海道
+              = JpPrefecture::Prefecture.find(@item.prefecture_code).name
           %tr.one
             %th 発送日の目安
             %td 


### PR DESCRIPTION
[What]
商品詳細ページの発送元地域の修正

[Why]
発送元地域のデータを仮に記述していたため