### PR TITLE
マイページのユーザー名修正

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -46,7 +46,8 @@
     .MyPage__todo
       .User__info
         = image_tag('member_photo_noimage_thumb.png',class: 'User__info__image')
-        %p ユーザー名
+        %p
+          = current_user.nickname
       .Todo__list
         %h1 やることリスト
         %ul


### PR DESCRIPTION
[What]
マイページのユーザー名の修正

[Why]
マイページにログインしているユーザー名を表示させるとことでわかりやすくなるため