### PR TITLE
payjp_key_environment_variable

### DIFF
--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -47,8 +47,7 @@ class CreditCardsController < ApplicationController
   end
   
   def set_payjp_api_key
-    # 後に環境変数にて設定予定。テスト用のSecretKeyのため、セキュリティ的には問題ない。
-    Payjp.api_key = 'sk_test_631078351a3b43065f7af39e'
+    Payjp.api_key = ENV["PAYJP_ACCESS_KEY"]
   end
 
   def set_credit_card_customer

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -117,8 +117,7 @@ class ItemsController < ApplicationController
   end
 
   def set_payjp_api_key
-    # 後に環境変数にて設定予定。テスト用のSecretKeyのため、セキュリティ的には問題ない。
-    Payjp.api_key = 'sk_test_631078351a3b43065f7af39e'
+    Payjp.api_key =  ENV["PAYJP_ACCESS_KEY"]
   end
 
   def set_credit_card_customer


### PR DESCRIPTION
##What
payjpのアクセスキーを環境変数に変更した。
##Why
githubに直接キーをpushするのはセキュリティ上、良くない為。